### PR TITLE
feat(logging): allow adding fields via `WithFields`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ func main() {
 	// This is how you can use a context to pass a logger around.
 	ctx := logging.WithLogger(context.Background(), logger)
 	printLogWithContext(ctx)
+
+	// This is how you can add fields to the logger in the context.
+	printLogWithContext(logging.WithFields(ctx, zap.String("key", "value")))
 }
 
 // This is how you can pass the logger around.

--- a/examples/logging/main.go
+++ b/examples/logging/main.go
@@ -25,6 +25,9 @@ func main() {
 	// This is how you can use a context to pass a logger around.
 	ctx := logging.WithLogger(context.Background(), logger)
 	printLogWithContext(ctx)
+
+	// This is how you can add fields to the logger in the context.
+	printLogWithContext(logging.WithFields(ctx, zap.String("key", "value")))
 }
 
 // This is how you can pass the logger around.

--- a/logging/context.go
+++ b/logging/context.go
@@ -19,6 +19,11 @@ func WithLogger(ctx context.Context, logger *zap.Logger) context.Context {
 	return context.WithValue(ctx, GetContextKey(), logger)
 }
 
+// WithFields adds fields to the logger in the context.
+func WithFields(ctx context.Context, fields ...zap.Field) context.Context {
+	return WithLogger(ctx, FromContext(ctx).With(fields...))
+}
+
 // FromContext returns the logger from the context.
 func FromContext(ctx context.Context) *zap.Logger {
 	if logger, ok := ctx.Value(GetContextKey()).(*zap.Logger); ok {

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -1,0 +1,31 @@
+package logging_test
+
+import (
+	"testing"
+
+	"github.com/nicklasfrahm-dev/appkit/logging"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestWithDefaultLogLevel(t *testing.T) {
+	// Arrange.
+	t.Parallel()
+
+	// Act.
+	logger := logging.NewLogger()
+
+	// Assert.
+	assert.Equal(t, zap.InfoLevel, logger.Level(), "should default to the info log level")
+}
+
+func TestWithCustomLogLevel(t *testing.T) {
+	// Arrange.
+	t.Setenv("LOG_LEVEL", "debug")
+
+	// Act.
+	logger := logging.NewLogger()
+
+	// Assert.
+	assert.Equal(t, zap.DebugLevel, logger.Level(), "should set the log level to debug")
+}


### PR DESCRIPTION
As I have been using loggers via the `context.Context` more extensively I noticed that it could be nice to have a helper function that adds fields to the logger in the context.

I've also added some missing test cases.